### PR TITLE
chore: stable source-prefixed objectIDs + dedup analysis scripts

### DIFF
--- a/check-dupes.ts
+++ b/check-dupes.ts
@@ -1,0 +1,65 @@
+import algoliasearch from 'algoliasearch';
+
+const ALGOLIA_APP = "1AWHE68HXJ";
+const ALGOLIA_WRITE = "3f984ae147d9a001b43ecf96d8201138";
+
+const client = algoliasearch(ALGOLIA_APP, ALGOLIA_WRITE);
+const index = client.initIndex('brevets');
+
+const allRecords: Array<{objectID: string, date?: string, distance?: number, country?: string, city?: string}> = [];
+
+await index.browseObjects({
+  attributesToRetrieve: ['objectID', 'date', 'distance', 'country', 'city'],
+  batch: (objects: any[]) => {
+    for (const obj of objects) {
+      allRecords.push(obj);
+    }
+  }
+});
+
+console.log(`Total records in Algolia: ${allRecords.length}`);
+
+const supabase = allRecords.filter(r => r.objectID.startsWith('supabase__'));
+const other = allRecords.filter(r => !r.objectID.startsWith('supabase__'));
+
+console.log(`Supabase records: ${supabase.length}`);
+console.log(`Non-supabase records: ${other.length}`);
+
+// Build a map from supabase records: date|distance|country|city -> objectID
+const normalize = (v?: string) => (v || '').trim().toLowerCase();
+const supabaseKeys = new Map<string, string>();
+for (const r of supabase) {
+  const key = [r.date, r.distance, normalize(r.country), normalize(r.city)].join('|');
+  supabaseKeys.set(key, r.objectID);
+}
+
+// Find non-supabase records that have a matching supabase record
+const dupes: Array<{old: string, new: string, key: string}> = [];
+for (const r of other) {
+  const key = [r.date, r.distance, normalize(r.country), normalize(r.city)].join('|');
+  if (supabaseKeys.has(key)) {
+    dupes.push({ old: r.objectID, new: supabaseKeys.get(key)!, key });
+  }
+}
+
+console.log(`\nDuplicates found: ${dupes.length}`);
+
+// Group by country
+const byCountry = new Map<string, number>();
+for (const d of dupes) {
+  const country = d.key.split('|')[2] || 'unknown';
+  byCountry.set(country, (byCountry.get(country) || 0) + 1);
+}
+const sorted = [...byCountry.entries()].sort((a, b) => b[1] - a[1]);
+console.log('\nDuplicates by country:');
+for (const [country, count] of sorted) {
+  console.log(`  ${count}\t${country}`);
+}
+
+console.log('\nSample duplicates:');
+for (const d of dupes.slice(0, 10)) {
+  console.log(`  ${d.old}  →  ${d.new}  (${d.key})`);
+}
+
+await Bun.write('dupes.json', JSON.stringify(dupes, null, 2));
+console.log(`\nFull list written to dupes.json`);

--- a/dedup.ts
+++ b/dedup.ts
@@ -1,0 +1,186 @@
+/**
+ * dedup.ts
+ *
+ * 1. Browse all Algolia records
+ * 2. For each non-supabase record that matches a supabase record (same
+ *    date + distance + country + city), verify they truly represent the same
+ *    event and that no data would be lost.
+ * 3. Produce a patch list: supabase records that should be updated to inherit
+ *    any extra data from the old record (e.g. _geoloc, map links).
+ * 4. Apply patches + delete old IDs (with --dry-run flag for safety).
+ */
+
+import algoliasearch from 'algoliasearch';
+
+const DRY_RUN = !process.argv.includes('--apply');
+
+const ALGOLIA_APP = "1AWHE68HXJ";
+const ALGOLIA_WRITE = "3f984ae147d9a001b43ecf96d8201138";
+
+const client = algoliasearch(ALGOLIA_APP, ALGOLIA_WRITE);
+const index = client.initIndex('brevets');
+
+type Record = {
+  objectID: string;
+  date?: string;
+  distance?: number;
+  country?: string;
+  city?: string;
+  name?: string;
+  _geoloc?: Array<{ lat: number; lng: number }>;
+  map?: string[];
+  site?: string;
+  mail?: string;
+  club?: string;
+  ascent?: number;
+  [key: string]: unknown;
+};
+
+console.log('Browsing Algolia index…');
+const allRecords: Record[] = [];
+await index.browseObjects<Record>({
+  batch: (objects) => {
+    for (const obj of objects) allRecords.push(obj);
+  },
+});
+console.log(`Fetched ${allRecords.length} records`);
+
+const normalize = (v?: string) => (v || '').trim().toLowerCase();
+const eventKey = (r: Record) =>
+  [r.date, r.distance, normalize(r.country), normalize(r.city)].join('|');
+
+const supabaseByKey = new Map<string, Record>();
+const supabaseById = new Map<string, Record>();
+const otherRecords: Record[] = [];
+
+for (const r of allRecords) {
+  if (r.objectID.startsWith('supabase__')) {
+    supabaseByKey.set(eventKey(r), r);
+    supabaseById.set(r.objectID, r);
+  } else {
+    otherRecords.push(r);
+  }
+}
+
+type DupeResult = {
+  old: Record;
+  base: Record;
+  issues: string[];
+  patch: Partial<Record> | null;
+};
+
+const results: DupeResult[] = [];
+const noMatch: Record[] = [];
+
+for (const old of otherRecords) {
+  const key = eventKey(old);
+  const base = supabaseByKey.get(key);
+  if (!base) {
+    noMatch.push(old);
+    continue;
+  }
+
+  const issues: string[] = [];
+  const patch: Partial<Record> = {};
+
+  // Check name similarity (warn if very different)
+  if (old.name && base.name) {
+    const oldName = normalize(old.name);
+    const baseName = normalize(base.name);
+    if (oldName !== baseName) {
+      issues.push(`name mismatch: "${old.name}" vs "${base.name}"`);
+    }
+  }
+
+  // Inherit geoloc if base is missing it
+  if ((!base._geoloc || base._geoloc.length === 0) && old._geoloc && old._geoloc.length > 0) {
+    patch._geoloc = old._geoloc;
+    issues.push(`old has _geoloc that base lacks → will patch`);
+  }
+
+  // Merge map links (union, URLs only)
+  const isUrl = (s: string) => /^https?:\/\/\S+$/i.test(s.trim());
+  const oldMaps = new Set((old.map ?? []).filter(isUrl));
+  const baseMaps = new Set(base.map ?? []);
+  const missingMaps = [...oldMaps].filter(m => !baseMaps.has(m));
+  const skippedMaps = (old.map ?? []).filter(m => !isUrl(m));
+  if (missingMaps.length > 0) {
+    patch.map = [...baseMaps, ...missingMaps];
+    issues.push(`old has extra map links: ${missingMaps.join(', ')} → will patch`);
+  }
+  if (skippedMaps.length > 0) {
+    issues.push(`skipped non-URL map entries: ${skippedMaps.join(', ')}`);
+  }
+
+  // Inherit site/mail if base is missing
+  if (!base.site && old.site) {
+    patch.site = old.site;
+    issues.push(`old has site that base lacks → will patch`);
+  }
+  if (!base.mail && old.mail) {
+    patch.mail = old.mail;
+    issues.push(`old has mail that base lacks → will patch`);
+  }
+
+  results.push({
+    old,
+    base,
+    issues,
+    patch: Object.keys(patch).length > 0 ? { objectID: base.objectID, ...patch } : null,
+  });
+}
+
+const withIssues = results.filter(r => r.issues.length > 0);
+const withPatches = results.filter(r => r.patch !== null);
+const cleanDupes = results.filter(r => r.issues.length === 0);
+
+console.log(`\n=== Summary ===`);
+console.log(`Confirmed duplicates: ${results.length}`);
+console.log(`  Clean (no data differences): ${cleanDupes.length}`);
+console.log(`  With issues/patches: ${withIssues.length}`);
+console.log(`    of which need patching: ${withPatches.length}`);
+console.log(`Non-supabase records with no supabase match: ${noMatch.length}`);
+
+if (withIssues.length > 0) {
+  console.log(`\n=== Sample issues ===`);
+  for (const r of withIssues.slice(0, 20)) {
+    console.log(`  ${r.old.objectID} → ${r.base.objectID}`);
+    for (const issue of r.issues) {
+      console.log(`    • ${issue}`);
+    }
+  }
+}
+
+const nameMismatches = withIssues.filter(r => r.issues.some(i => i.includes('name mismatch')));
+console.log(`\nName mismatches (possible false positives): ${nameMismatches.length}`);
+console.log('Full name mismatch list:');
+for (const r of nameMismatches) {
+  console.log(`  ${r.old.objectID} → ${r.base.objectID}`);
+  console.log(`    old:  "${r.old.name}"`);
+  console.log(`    base: "${r.base.name}"`);
+  console.log(`    key:  ${eventKey(r.old)}`);
+}
+
+await Bun.write('dupes-analysis.json', JSON.stringify({ results, noMatch }, null, 2));
+console.log(`\nFull analysis written to dupes-analysis.json`);
+
+if (DRY_RUN) {
+  console.log(`\n[DRY RUN] Would delete ${results.length} old IDs from Algolia`);
+  console.log(`[DRY RUN] Would patch ${withPatches.length} supabase records`);
+  console.log(`\nRun with --apply to execute`);
+} else {
+  console.log(`\nApplying patches…`);
+  const patches = withPatches.map(r => r.patch!);
+  if (patches.length > 0) {
+    await index.partialUpdateObjects(patches, { createIfNotExists: false });
+    console.log(`Patched ${patches.length} records`);
+  }
+
+  console.log(`Deleting ${results.length} stale IDs…`);
+  const toDelete = results.map(r => r.old.objectID);
+  // Delete in batches of 1000
+  for (let i = 0; i < toDelete.length; i += 1000) {
+    await index.deleteObjects(toDelete.slice(i, i + 1000));
+  }
+  console.log(`Deleted ${toDelete.length} records`);
+}

--- a/src/admin/export-auk.ts
+++ b/src/admin/export-auk.ts
@@ -1,6 +1,5 @@
 import { Brevet } from '../types';
 import { checkOk } from './fetch-utils';
-import { countByKey, makeCollisionSafeObjectID } from './id-utils';
 
 type CalendarRaw = {
   Name: string;
@@ -105,8 +104,6 @@ function cleanBrevets(brevets: CalendarRaw[]): Brevet[] {
     const city = (brevet.StartLocation || '').trim();
     const country = 'UK';
     const distance = brevet.NominalDistance || brevet.Distance;
-    const baseObjectID = [date, distance, country, city.replace(/\W+/g, '_')].join('__');
-
     return {
       brevet,
       date,
@@ -114,24 +111,12 @@ function cleanBrevets(brevets: CalendarRaw[]): Brevet[] {
       city,
       country,
       distance,
-      baseObjectID,
     };
   });
 
-  const counts = countByKey(prepared.map((x) => x.baseObjectID));
-
   return prepared.map(
-    ({ brevet, date, dateNumber, city, country, distance, baseObjectID }) => {
-      const objectID = makeCollisionSafeObjectID(
-        baseObjectID,
-        counts,
-        [
-          brevet.Name || '',
-          brevet.OrganizerName || '',
-          brevet.Url || '',
-          brevet.Id || '',
-        ].join('|')
-      );
+    ({ brevet, date, dateNumber, city, country, distance }) => {
+      const objectID = 'auk__' + brevet.Id;
 
       return {
         objectID,

--- a/src/admin/export-belgium.ts
+++ b/src/admin/export-belgium.ts
@@ -1,6 +1,5 @@
 import { Brevet } from '../types';
 import { checkOk } from './fetch-utils';
-import { countByKey, makeCollisionSafeObjectID } from './id-utils';
 import he from 'he';
 import * as cheerio from 'cheerio';
 
@@ -119,8 +118,6 @@ function cleanBrevets(brevets: Raw[]): Brevet[] {
     const { year, month, day } = brevet.start_date_details;
     const date = [day, month, year].join('/');
     const dateNumber = parseInt([year, month, day].join(''), 10);
-    const baseObjectID = [date, distance, country, city].join('__');
-
     const $ = cheerio.load(brevet.description);
 
     return {
@@ -132,24 +129,12 @@ function cleanBrevets(brevets: Raw[]): Brevet[] {
       date,
       dateNumber,
       $,
-      baseObjectID,
     };
   });
 
-  const counts = countByKey(prepared.map((x) => x.baseObjectID));
-
   return prepared.map(
-    ({ brevet, distance, country, city, title, date, dateNumber, $, baseObjectID }) => {
-      const objectID = makeCollisionSafeObjectID(
-        baseObjectID,
-        counts,
-        [
-          title,
-          brevet.slug,
-          brevet.url,
-          ($('a[href^=mailto:]').attr('href') || '').replace('mailto:', ''),
-        ].join('|')
-      );
+    ({ brevet, distance, country, city, title, date, dateNumber, $ }) => {
+      const objectID = 'belgium__' + brevet.id;
 
       return {
         objectID,

--- a/src/admin/export-netherlands.ts
+++ b/src/admin/export-netherlands.ts
@@ -22,7 +22,7 @@ async function fetchBrevets(): Promise<Raw[]> {
   const url = new URL('https://randonneurs.nl/api/v1/events');
   url.search = new URLSearchParams({
     from: new Date().toISOString().split('T')[0],
-    until: '2026-01-01',
+    until: '2027-01-01',
   }).toString();
 
   const events: Raw[] = await fetch(url)
@@ -43,8 +43,12 @@ function cleanBrevets(brevets: Raw[]): Brevet[] {
     const mail = brevet.contact.email;
     const club = 'Randonneurs NL';
 
+    // Extract stable numeric ID from event URL, e.g. "https://randonneurs.nl/nl/event/653/BRM-..."
+    const urlIdMatch = brevet.url.match(/\/event\/(\d+)\//);
+    const urlId = urlIdMatch ? urlIdMatch[1] : brevet.url.replace(/^https?:\/\//, '').replace(/\/$/, '');
+
     return {
-      objectID: [date, distance, country, city].join('__'),
+      objectID: 'nl__' + urlId,
       date,
       dateNumber,
       name: title,


### PR DESCRIPTION
## What

4,300 duplicate records exist in Algolia: old-style \`date__distance__country__city\` IDs coexist alongside newer \`supabase__\` IDs for the same real-world events. This is because the ACP map source (\`export-map.ts\`) covers events worldwide and was added later — records already indexed with the old ID scheme were never cleaned up.

## Analysis

\`check-dupes.ts\` browses all 23,936 Algolia records and finds non-supabase records with a matching supabase record (same date+distance+country+city). Result: **4,300 duplicates** across almost every country:

- USA: 528, India: 498, Japan: 462, France: 359, Australia: 259, Canada: 232, Sweden: 151, Spain: 136, Ukraine: 122…

## One-time cleanup

\`dedup.ts\` (dry-run by default, \`--apply\` to execute):
1. Fetches full records for both sides
2. Verifies they are true duplicates (41 name mismatches inspected — all are genuine duplicates where old record had a generic placeholder name like \`BRM 200 – CHARLEROI\` vs the real route name in supabase)
3. Patches supabase records with any data only the old record had (140 records need patching: map URLs from OpenRunner/RideWithGPS, site/mail from Ireland/Belgium scrapers)
4. Deletes the 4,300 stale old IDs

**Not yet run with \`--apply\`.**

## Structural fix: stable source-prefixed IDs

Sources that expose a stable internal ID now use it directly, eliminating future duplicates for those sources:

- \`export-belgium.ts\`: \`belgium__<wordpress_id>\` (was \`date__distance__Belgium__city\`)
- \`export-auk.ts\`: \`auk__<event_id>\` (was \`date__distance__UK__city\`)
- \`export-netherlands.ts\`: \`nl__<numeric_id>\` (was \`date__distance__The Netherlands__city\`; also fixes \`until\` date that was stuck at \`2026-01-01\`)

Sources **without** a stable internal ID (RUSA, Ireland, Italy) still use \`date__distance__country__city\`. These don't overlap with supabase (independent organisations), so they don't generate duplicates today — but the ID scheme is still fragile.

## Open question: ID strategy for sources without stable IDs

The right long-term approach is probably **Option B: surrogate IDs assigned on first encounter, persisted in \`brevets.json\`**:
- On first ingest of a RUSA/Ireland/Italy record, hash a source-specific fingerprint and assign \`brm__<hash>\`
- Store it in \`brevets.json\` as the canonical ID registry
- On subsequent runs, look up the existing record by fingerprint and reuse the stored ID

This means \`brevets.json\` becomes an accumulative registry (needed for history preservation anyway), and IDs are immutable after creation regardless of how fields change.

This was deferred — the current \`date__distance__country__city\` scheme for those sources is unchanged, and the merge logic in \`export.ts\` continues to handle supabase reconciliation.

## To do before merging

- [ ] Run \`bun dedup.ts --apply\` to clean up the 4,300 Algolia duplicates
- [ ] Decide on surrogate ID strategy for RUSA/Ireland/Italy
- [ ] After next export with new IDs, run \`bun dedup.ts\` again to catch newly-stale \`date__distance__Belgium__*\` and \`date__distance__UK__*\` IDs in Algolia